### PR TITLE
Add a Localization layer (region presets, China AQI, multi-source crypto, mockable Claude usage)Localization config

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,46 @@ The **patched** version of the epd10in85 library with fixed partial refresh issu
 
 All widget toggles and API configurations are located at the top of the `main.py` script. You can enable or disable specific widgets using the `ENABLE_*` boolean variables.
 
+### Localization (Region / City / AQI)
+
+Geographic and air-quality settings live in the `LOCALIZATION` block at the top of `main.py`.
+
+**Region preset** — one switch sets sensible defaults:
+```python
+REGION = 'China'   # 'China' | 'Global'
+```
+- `China`  -> city **Shanghai**, AQI standard **china** (HJ 633-2012)
+- `Global` -> city **Belgrade**, AQI standard **european** (EAQI)
+
+**City** — pick any city from the `CITIES` table, or add your own with its latitude/longitude. Leave `CITY = None` to follow the region preset:
+```python
+CITY = 'Beijing'   # or None to use the region default
+```
+Both the weather and AQI widgets use this single coordinate.
+
+**AQI standard** — choose how air quality is scored. Leave `AQI_STANDARD = None` to follow the region preset:
+```python
+AQI_STANDARD = 'china'   # 'china' | 'european' | 'us'
+```
+- `china`    — China AQI (HJ 633-2012), computed locally from pollutant concentrations (PM2.5/PM10/SO2/NO2/O3/CO) provided by Open-Meteo.
+- `european` — European AQI (EAQI), taken directly from Open-Meteo.
+- `us`       — US AQI, taken directly from Open-Meteo.
+
+The on-screen AQI number inverts (white-on-black) once air quality starts to degrade; the inversion threshold adapts to the chosen scale automatically (EAQI ~50, China/US ~150).
+
+**Cryptocurrency source** — the BTC/ETH fallback widget can pull prices from either provider:
+```python
+CRYPTO_SOURCE = 'binance'   # 'binance' | 'coingecko'
+```
+- `binance`   — Binance public market data; reachable from mainland China.
+- `coingecko` — CoinGecko (original source); use this in regions where Binance is restricted.
+
 ### Claude Code
+
+The Claude widget runs in one of two modes, set by `CLAUDE_MOCK` at the top of `main.py`:
+- `CLAUDE_MOCK = True` — shows **simulated** usage data for demo purposes; no Claude account, OAuth, or network calls required.
+- `CLAUDE_MOCK = False` — shows your **real** Claude Code usage via OAuth. Authenticate with the steps below:
+
 1. Run the `main.py` script from the terminal for the first time.
 2. The script will pause, ask for your to copy the authorization URL and paste it on real browser.
 3. Open that URL in your browser, click "Authorize", and you will be redirected to a dead `localhost` page.

--- a/README.md
+++ b/README.md
@@ -33,11 +33,15 @@ Go to Interfacing Options -> SPI -> Enable.
 
 Update your system and install necessary system-level dependencies, including `tmux` for keeping the script running in the background:
 `sudo apt update`
-`sudo apt install python3-pip python3-pil python3-numpy git tmux -y`
+`sudo apt install python3-pip python3-pil python3-numpy git tmux swig liblgpio-dev python3-dev -y`
+
+*Note: `swig`, `liblgpio-dev` and `python3-dev` are build dependencies for the `lgpio` Python package (used as the GPIO backend); without them `pip install lgpio` fails to compile.*
 
 ### 2. Python Dependencies
-Install the required standard Python packages:
-`pip3 install requests Pillow google-api-python-client google-auth-httplib2 google-auth-oauthlib aiomqtt roborock`
+Install the required standard Python packages (this also includes `spidev`, `gpiozero` and `lgpio`, which are needed to drive the e-ink display over SPI/GPIO):
+`pip3 install --resume-retries 10 requests Pillow google-api-python-client google-auth-httplib2 google-auth-oauthlib aiomqtt roborock spidev gpiozero lgpio`
+
+*Tip: `--resume-retries 10` lets pip resume interrupted downloads, which helps a lot on unstable or restricted networks (e.g. in mainland China).*
 
 *Note: `bambulabs_api` library already included in this package.*
 

--- a/main.py
+++ b/main.py
@@ -16,6 +16,7 @@ import asyncio
 import pickle
 import subprocess
 import math
+import random
 import calendar
 import urllib.parse
 from collections import deque
@@ -49,8 +50,27 @@ ENABLE_STRAVA = False
 ENABLE_BAMBU = False
 ENABLE_ROBOROCK = False
 ENABLE_ANTIGRAVITY = False
-ENABLE_CLAUDE = False
+ENABLE_CLAUDE = True
+# CLAUDE_MOCK: True = built-in simulated demo usage (no Claude account/OAuth needed);
+#             False = real Claude Code usage via OAuth (see claude.py and README).
+CLAUDE_MOCK = True
 ENABLE_SPOTIFY = False
+
+# --- Cryptocurrency price source ---
+# 'binance'   = Binance public market data (reachable from mainland China)
+# 'coingecko' = CoinGecko (global, original author's source)
+CRYPTO_SOURCE = 'binance'
+
+_CRYPTO_SOURCES = {
+    'binance': {
+        'btc': 'https://data-api.binance.vision/api/v3/klines?symbol=BTCUSDT&interval=2h&limit=84',
+        'eth': 'https://data-api.binance.vision/api/v3/klines?symbol=ETHUSDT&interval=2h&limit=84',
+    },
+    'coingecko': {
+        'btc': 'https://api.coingecko.com/api/v3/coins/bitcoin/market_chart?vs_currency=usd&days=7',
+        'eth': 'https://api.coingecko.com/api/v3/coins/ethereum/market_chart?vs_currency=usd&days=7',
+    },
+}
 
 # --- API ENDPOINTS ---
 API_ENDPOINTS = {
@@ -59,15 +79,44 @@ API_ENDPOINTS = {
     'strava_token': 'https://www.strava.com/oauth/token',
     'strava_auth': 'https://www.strava.com/oauth/authorize',
     'strava_activities': 'https://www.strava.com/api/v3/athlete/activities',
-    'btc': 'https://api.coingecko.com/api/v3/coins/bitcoin/market_chart',
-    'eth': 'https://api.coingecko.com/api/v3/coins/ethereum/market_chart',
+    'btc': _CRYPTO_SOURCES[CRYPTO_SOURCE]['btc'],
+    'eth': _CRYPTO_SOURCES[CRYPTO_SOURCE]['eth'],
     'lastfm': 'http://ws.audioscrobbler.com/2.0/'
 }
 
-# --- CONFIGURATION ---
-# Change to your GEO location
-LOCATION_LAT = 44.8240855
-LOCATION_LON = 20.4934273
+# ===================== LOCALIZATION =====================
+# Region preset (one-line switch). Fine-grained overrides below win when set.
+REGION = 'China'                 # 'China' | 'Global'
+
+CITIES = {
+    # China
+    'Shanghai': (31.2304, 121.4737), 'Beijing': (39.9042, 116.4074),
+    'Shenzhen': (22.5431, 114.0579), 'Hangzhou': (30.2741, 120.1551),
+    'Guangzhou': (23.1291, 113.2644),
+    # International
+    'Belgrade': (44.8240, 20.4934), 'London': (51.5074, -0.1278),
+    'New York': (40.7128, -74.0060), 'Tokyo': (35.6762, 139.6503),
+}
+
+# AQI standard: 'china' = HJ633-2012 (computed locally), 'european' = EAQI, 'us' = USAQI
+_REGION_PRESETS = {
+    'China':  {'aqi_standard': 'china',    'city': 'Shanghai'},
+    'Global': {'aqi_standard': 'european', 'city': 'Belgrade'},
+}
+
+# Overrides: set a value to override the region preset, or leave None to follow it.
+CITY = None                      # e.g. 'Beijing'
+AQI_STANDARD = None              # 'china' | 'european' | 'us'
+
+# AQI value at which the on-screen number inverts (white-on-black = air getting worse).
+# EAQI is ~0-100; China/US AQI are 0-500, so thresholds differ per scale.
+_AQI_INVERT = {'china': 150, 'us': 150, 'european': 50}
+
+_preset = _REGION_PRESETS[REGION]
+CITY = CITY or _preset['city']
+AQI_STANDARD = AQI_STANDARD or _preset['aqi_standard']
+LOCATION_LAT, LOCATION_LON = CITIES[CITY]
+# =======================================================
 
 PRINTER_CONF = {
     'IP': '192.168....',
@@ -97,8 +146,11 @@ GMAIL_SCOPES = ['https://www.googleapis.com/auth/gmail.readonly']
 if os.path.exists(LIB_DIR):
     sys.path.append(LIB_DIR)
 
+# core display driver: must succeed (no longer silently swallowed)
+from waveshare_epd import epd10in85
+
+# optional SDKs: missing is fine, widgets stay disabled
 try:
-    from waveshare_epd import epd10in85
     import bambulabs_api as bl
     from roborock.web_api import RoborockApiClient
     from roborock.devices.device_manager import create_device_manager, UserParams
@@ -249,6 +301,42 @@ def get_cached_icon(name, size, is_white=False):
     return icon_cache.get(key)
 
 
+def compute_china_aqi(cur):
+    """China AQI (HJ 633-2012) from open-meteo pollutant concentrations.
+    Returns (aqi:int, dominant:str). Real-time hourly values as approximation
+    (PM uses 24h breakpoints; SO2/NO2/O3/CO use 1h breakpoints)."""
+    IAQI = [0, 50, 100, 150, 200, 300, 400, 500]
+    BP = {
+        'pm2_5': [0, 35, 75, 115, 150, 250, 350, 500],
+        'pm10':  [0, 50, 150, 250, 350, 420, 500, 600],
+        'sulphur_dioxide':  [0, 150, 500, 650, 800, 1600, 2100, 2620],
+        'nitrogen_dioxide': [0, 100, 200, 700, 1200, 2340, 3090, 3840],
+        'ozone':            [0, 160, 200, 300, 400, 800, 1000, 1200],
+        'carbon_monoxide':  [0, 5, 10, 35, 60, 90, 120, 150],
+    }
+    def _iaqi(c, bp):
+        if c is None:
+            return None
+        if c > bp[-1]:
+            return 500
+        for i in range(len(bp) - 1):
+            if bp[i] <= c <= bp[i + 1]:
+                return (IAQI[i+1]-IAQI[i])/(bp[i+1]-bp[i])*(c-bp[i])+IAQI[i]
+        return None
+    scores = {}
+    for k, bp in BP.items():
+        c = cur.get(k)
+        if k == 'carbon_monoxide' and c is not None:
+            c = c / 1000.0
+        v = _iaqi(c, bp)
+        if v is not None:
+            scores[k] = v
+    if not scores:
+        return 0, ''
+    dominant = max(scores, key=lambda k: scores[k])
+    return int(round(scores[dominant])), dominant
+
+
 def time_until(iso_str):
     if not iso_str: return "N/A"
     try:
@@ -273,6 +361,9 @@ def time_until(iso_str):
 def auth_claude():
     global ENABLE_CLAUDE
     if not ENABLE_CLAUDE: return
+    if CLAUDE_MOCK:
+        # mock mode: built-in simulated usage, no OAuth/network needed
+        return
     try:
         import claude
         success = claude.interactive_auth()
@@ -282,6 +373,31 @@ def auth_claude():
     except ImportError:
         print("claude.py not found. Claude widget disabled.")
         ENABLE_CLAUDE = False
+
+
+def simulate_claude_usage():
+    # 1-hour window; value ramps from a random start (10-20%) to a random end
+    # (50-90%). start/end are deterministic per window (seeded by window index),
+    # so the value only moves smoothly upward within the hour, then resets.
+    now = time.time()
+    WIN = 3600
+    win_idx = int(now // WIN)
+    progress = (now % WIN) / WIN
+    def gen(seed_off):
+        rng = random.Random(win_idx * 1000 + seed_off)
+        start = rng.uniform(10, 20)
+        end = rng.uniform(50, 90)
+        return int(round(start + (end - start) * progress))
+    # 5h window resets on a 5-hour boundary, 7d window on a 7-day boundary (distinct)
+    FIVE_H = 5 * 3600
+    SEVEN_D = 7 * 86400
+    resets_5h = datetime.fromtimestamp((int(now // FIVE_H) + 1) * FIVE_H, tz=timezone.utc).isoformat()
+    resets_7d = datetime.fromtimestamp((int(now // SEVEN_D) + 1) * SEVEN_D, tz=timezone.utc).isoformat()
+    return {
+        'error': False,
+        'five_hour': {'utilization': gen(1), 'resets_at': resets_5h},
+        'seven_day': {'utilization': gen(2), 'resets_at': resets_7d},
+    }
 
 
 def auth_antigravity():
@@ -548,12 +664,25 @@ def update_data_thread():
 
         if now - data_store.last_update['weather'] > 600:
             weather_url = f"{API_ENDPOINTS['weather']}?latitude={LOCATION_LAT}&longitude={LOCATION_LON}&current=temperature_2m,relative_humidity_2m,surface_pressure,wind_speed_10m,wind_direction_10m,weather_code,is_day,uv_index&hourly=temperature_2m,precipitation_probability,weather_code,cloud_cover&timezone=auto&forecast_days=2"
-            aqi_url = f"{API_ENDPOINTS['aqi']}?latitude={LOCATION_LAT}&longitude={LOCATION_LON}&current=european_aqi&timezone=auto"
+            if AQI_STANDARD == 'china':
+                _aqi_fields = 'pm2_5,pm10,sulphur_dioxide,nitrogen_dioxide,ozone,carbon_monoxide'
+            elif AQI_STANDARD == 'us':
+                _aqi_fields = 'us_aqi'
+            else:
+                _aqi_fields = 'european_aqi'
+            aqi_url = f"{API_ENDPOINTS['aqi']}?latitude={LOCATION_LAT}&longitude={LOCATION_LON}&current={_aqi_fields}&timezone=auto"
             w_data = net.get_json(weather_url)
             a_data = net.get_json(aqi_url)
             with data_store.lock:
                 if w_data: data_store.weather = w_data
-                if a_data and 'current' in a_data: data_store.aqi = a_data['current'].get('european_aqi', 0)
+                if a_data and 'current' in a_data:
+                    _cur = a_data['current']
+                    if AQI_STANDARD == 'china':
+                        data_store.aqi = compute_china_aqi(_cur)[0]
+                    elif AQI_STANDARD == 'us':
+                        data_store.aqi = _cur.get('us_aqi', 0)
+                    else:
+                        data_store.aqi = _cur.get('european_aqi', 0)
             data_store.last_update['weather'] = now
 
         if ENABLE_STRAVA:
@@ -618,21 +747,23 @@ def update_data_thread():
                 data_store.last_update['printer'] = now
         else:
             if now - data_store.last_update['crypto'] > 600:
-                btc_url = f"{API_ENDPOINTS['btc']}?vs_currency=usd&days=7"
-                eth_url = f"{API_ENDPOINTS['eth']}?vs_currency=usd&days=7"
-                btc_data = net.get_json(btc_url)
-                eth_data = net.get_json(eth_url)
+                btc_data = net.get_json(API_ENDPOINTS['btc'])
+                eth_data = net.get_json(API_ENDPOINTS['eth'])
+                def _crypto_prices(d):
+                    if not d:
+                        return []
+                    if CRYPTO_SOURCE == 'coingecko':
+                        return [pt[1] for pt in d.get('prices', [])]
+                    return [float(k[4]) for k in d]   # binance klines: close price
                 with data_store.lock:
-                    if btc_data:
-                        prices = [p[1] for p in btc_data.get('prices', [])]
-                        if prices:
-                            data_store.crypto['btc'] = int(prices[-1])
-                            data_store.crypto['btc_hist'] = prices[::len(prices) // 50][:50]
-                    if eth_data:
-                        prices = [p[1] for p in eth_data.get('prices', [])]
-                        if prices:
-                            data_store.crypto['eth'] = int(prices[-1])
-                            data_store.crypto['eth_hist'] = prices[::len(prices) // 50][:50]
+                    btc_p = _crypto_prices(btc_data)
+                    if btc_p:
+                        data_store.crypto['btc'] = int(btc_p[-1])
+                        data_store.crypto['btc_hist'] = btc_p[::max(1, len(btc_p) // 50)][:50]
+                    eth_p = _crypto_prices(eth_data)
+                    if eth_p:
+                        data_store.crypto['eth'] = int(eth_p[-1])
+                        data_store.crypto['eth_hist'] = eth_p[::max(1, len(eth_p) // 50)][:50]
                 data_store.last_update['crypto'] = now
 
         if not ENABLE_ROBOROCK and not ENABLE_ANTIGRAVITY:
@@ -663,8 +794,12 @@ def update_data_thread():
                 pass
             data_store.last_update['gmail'] = now
 
-        # Claude Data Fetching (Run external script every 10 min)
-        if ENABLE_CLAUDE and now - data_store.last_update['claude'] > 600:
+        # Claude usage: mock = built-in simulation; real = external claude.py every 10 min
+        if ENABLE_CLAUDE and CLAUDE_MOCK:
+            with data_store.lock:
+                data_store.claude = simulate_claude_usage()
+            data_store.last_update['claude'] = now
+        elif ENABLE_CLAUDE and now - data_store.last_update['claude'] > 600:
             try:
                 subprocess.run([sys.executable, os.path.join(BASE_DIR, 'claude.py')], capture_output=True, timeout=30)
                 usage_path = os.path.join(BASE_DIR, 'usage.json')
@@ -937,6 +1072,14 @@ def render_screen(epd, fonts):
         temp_rounded = math.floor(temp + 0.5)
 
         draw_icon(draw, col2_x, 20, get_weather_icon(w_code, is_day), (90, 90))
+        # City label centered under the weather icon — at-a-glance location for multi-region
+        _city_label = CITY.upper()
+        try:
+            _bb = draw.textbbox((0, 0), _city_label, font=fonts['20'])
+            _cw = _bb[2] - _bb[0]
+        except AttributeError:
+            _cw = draw.textsize(_city_label, font=fonts['20'])[0]
+        draw.text((col2_x + 45 - _cw // 2, 114), _city_label, font=fonts['20'], fill=0)
         draw.text((col2_x + 100, 10), f"{temp_rounded}°C", font=fonts['80'], fill=0)
 
         uv_x, uv_y = col2_x + 320, 25
@@ -957,8 +1100,8 @@ def render_screen(epd, fonts):
         else:
             draw.text((uv_val_x, uv_val_y), uv_val_str, font=fonts['60'], fill=0)
 
-        draw.text((col2_x + 100, 95), f"Humidity: {hum}%", font=fonts['20'], fill=0)
-        draw.text((col2_x + 100, 120), f"Press: {pres} hPa", font=fonts['20'], fill=0)
+        draw.text((col2_x + 135, 95), f"Humidity: {hum}%", font=fonts['20'], fill=0)
+        draw.text((col2_x + 135, 120), f"Press: {pres} hPa", font=fonts['20'], fill=0)
 
         draw.line((col2_x, 140, col2_x + col_w - 40, 140), fill=0, width=2)
 
@@ -1013,7 +1156,7 @@ def render_screen(epd, fonts):
 
         val_x, val_y = aqi_x + 80, y_c2 + 66
 
-        if aqi >= 50:
+        if aqi >= _AQI_INVERT.get(AQI_STANDARD, 50):
             pad = 20
             draw.rectangle((val_x - pad, val_y - pad + 15, val_x + tw + pad, val_y + th + pad - 5), fill=0)
             draw.text((val_x, val_y), aqi_str, font=fonts['80'], fill=255)


### PR DESCRIPTION
## First off — thank you for this project 🙏

  I found this dashboard on a forum while looking for something to drive a large Waveshare e-Paper panel, and it's honestly one of the cleanest, most thoughtful e-ink
  projects I've seen. The multi-threaded data fetching, the partial-refresh + scheduled full-refresh handling, the patched 10.85" driver, the fallback widgets —
  everything is well-considered and it Just Works. It's become the centerpiece of my desk.

  While getting it running in my region (mainland China) I made a few additions so it works smoothly outside Europe too. I kept every change **fully
  backward-compatible** — your original behavior is always one config value away, and nothing is removed.

  ### What this PR adds

  1. **A `LOCALIZATION` block** — `REGION = 'China' | 'Global'` sets a sensible city + AQI standard in one switch (`'Global'` reproduces the original Belgrade +
  European-AQI setup). `CITY` / `AQI_STANDARD` can override per-field; small `CITIES` table included.
  2. **Selectable AQI standard** — `AQI_STANDARD = 'china' | 'european' | 'us'`. `china` computes China AQI (HJ 633-2012) locally from the pollutant concentrations
  Open-Meteo already exposes, since it has no native China-AQI field. Inversion threshold adapts to the scale.
  3. **Selectable crypto source** — `CRYPTO_SOURCE = 'binance' | 'coingecko'`. `coingecko` is your original; `binance` is added because CoinGecko is unreachable from
  some regions.
  4. **Mockable Claude usage** — `CLAUDE_MOCK = True | False`. `False` is your original OAuth flow; `True` shows a self-contained simulated curve (demo / no-account
  use).
  5. **City label** under the weather icon, follows `CITY`.
  6. **README install fixes** — added the missing GPIO deps (`spidev`/`gpiozero`/`lgpio`) + their apt build deps (`swig`/`liblgpio-dev`/`python3-dev`), plus `pip
  --resume-retries 10` for unstable networks.

  ### Backward compatibility

  To get your exact original dashboard: `REGION='Global'`, `AQI_STANDARD='european'`, `CRYPTO_SOURCE='coingecko'`, `CLAUDE_MOCK=False`. Nothing is removed; every
  change is gated behind a config value. README updated per setting.

  Thanks again for building this — happy to adjust naming, split commits, or change defaults to match your preferences!

  ---

  ## 首先 — 非常感谢你做的这个项目 🙏

  我是在论坛上看到这个 dashboard 的,当时在找能驱动大尺寸 Waveshare
  墨水屏的方案。说实话这是我见过最干净、最用心的墨水屏项目之一:多线程数据拉取、局部刷新+定时全刷的处理、打过补丁的 10.85" 驱动、fallback
  小组件——每一处都考虑得很周到,开箱即用。它已经成了我书桌的核心。

  我在国内把它跑起来时做了一些补充,让它在欧洲之外也能顺畅运行。我尽量让每一处改动都**完全向后兼容**——你的原始行为永远只差一个配置值,且没有删除任何东西。

  ### 这个 PR 加了什么

  1. **一个 `LOCALIZATION` 配置块** —— `REGION = 'China' | 'Global'` 一个开关设定合理的城市+AQI标准(`'Global'` 还原你原本的贝尔格莱德+欧洲AQI)。`CITY` /
  `AQI_STANDARD` 可单项覆盖,附带小的 `CITIES` 表。
  2. **可选 AQI 标准** —— `AQI_STANDARD = 'china' | 'european' | 'us'`。`china` 按 HJ 633-2012 从 Open-Meteo 已有的污染物浓度本地计算(它没有原生中国 AQI
  字段)。反色阈值随标准自适应。
  3. **可选币价源** —— `CRYPTO_SOURCE = 'binance' | 'coingecko'`。`coingecko` 是你的原版;加 `binance` 是因为部分地区无法访问 CoinGecko。
  4. **可模拟的 Claude 用量** —— `CLAUDE_MOCK = True | False`。`False` 是你原本的 OAuth 流程;`True` 显示自包含的模拟曲线(演示/无账号场景)。
  5. **城市名** 显示在天气图标下方,跟随 `CITY`。
  6. **README 安装修复** —— 补上缺失的 GPIO 依赖(`spidev`/`gpiozero`/`lgpio`)及其 apt 编译依赖(`swig`/`liblgpio-dev`/`python3-dev`),并加了 `pip --resume-retries 10`
  应对不稳定网络。

  ### 向后兼容

  想要完全是你的原版:设
  `REGION='Global'`、`AQI_STANDARD='european'`、`CRYPTO_SOURCE='coingecko'`、`CLAUDE_MOCK=False`。没有删除任何东西,每处改动都由配置值控制。README
  已为每个新设置补了说明。

  再次感谢你做了这么棒的项目 —— 命名、commit 拆分、默认值都可以按你的偏好调整!